### PR TITLE
Fix glob bug

### DIFF
--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -682,7 +682,7 @@ class BaseUri(object):
     @with_connection
     def islink(self):
         """
-        islink: 
+        islink:
 
         @rtype: bool
         @return: Indicates whether the file this path is pointing to is a
@@ -1016,9 +1016,8 @@ class FileSystem(object):
         # TODO-std: is this working with separators?
         res = []
         for f in path.listdir():
-            f = path / f
-            if fnmatch.fnmatch(self._path(f), pattern):
-                res.append(f)
+            if fnmatch.fnmatch(f, pattern):
+                res.append(path / f)
         return res
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="abl.vpath",
-    version="0.7",
+    version="0.8",
     description="A OO-abstraction of file-systems",
     author="Stephan Diehl",
     author_email="stephan.diehl@ableton.com",

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,6 +6,7 @@ from __future__ import with_statement
 import sys
 from functools import wraps
 from abl.vpath.base import *
+from abl.vpath.base.fs import CONNECTION_REGISTRY
 
 
 def os_create_file(some_file, content='content'):
@@ -50,3 +51,9 @@ def windows_only(func):
         func(*args, **kwargs)
 
     return _decorator
+
+
+class CleanupMemoryBeforeTestMixin(object):
+
+    def setUp(self):
+        CONNECTION_REGISTRY.cleanup(force=True)

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -3,21 +3,23 @@
 #******************************************************************************
 
 from __future__ import with_statement
-import datetime
 import os
-import time
 import tempfile
 import stat
-import sys
 from posixpath import join as ujoin
 from unittest import TestCase
-import logging
 import shutil
-from common import create_file, os_create_file, load_file, mac_only, is_on_mac
+
 from abl.vpath.base import *
-from abl.vpath.base.fs import CONNECTION_REGISTRY
 from abl.vpath.base.exceptions import FileDoesNotExistError
 
+from .common import (
+    create_file,
+    os_create_file,
+    load_file,
+    is_on_mac,
+    CleanupMemoryBeforeTestMixin,
+)
 
 class CommonFileSystemTest(TestCase):
     __test__ = False

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -21,10 +21,12 @@ from .common import (
     CleanupMemoryBeforeTestMixin,
 )
 
-class CommonFileSystemTest(TestCase):
+
+class CommonFileSystemTest(CleanupMemoryBeforeTestMixin, TestCase):
     __test__ = False
 
     def setUp(self):
+        super(CommonFileSystemTest, self).setUp()
         self.local_setup()
         self.foo_path = URI(self.baseurl) / 'foo'
         self.existing_dir = ujoin(self.baseurl, 'foo')
@@ -256,7 +258,6 @@ class TestMemoryFileSystem(CommonFileSystemTest):
     __test__ = True
 
     def local_setup(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
         self.baseurl = "memory:///"
 
         foo_path = URI(self.baseurl) / 'foo'
@@ -373,11 +374,11 @@ class TestLocalFSCopy2(CommonFSCopyTest):
         shutil.rmtree(self.tmpdir)
 
 
-class TestMemoryFSCopy2(CommonFSCopyTest):
+class TestMemoryFSCopy2(CleanupMemoryBeforeTestMixin, CommonFSCopyTest):
     __test__ = True
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestMemoryFSCopy2, self).setUp()
         self.baseurl = "memory:///"
 
     def tearDown(self):
@@ -418,11 +419,11 @@ class TestLocalFSExec(CommonFSExecTest):
         shutil.rmtree(self.tmpdir)
 
 
-class TestMemoryFSExec(CommonFSExecTest):
+class TestMemoryFSExec(CleanupMemoryBeforeTestMixin, CommonFSExecTest):
     __test__ = True
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestMemoryFSExec, self).setUp()
         self.baseurl = "memory:///"
 
     def tearDown(self):
@@ -590,11 +591,11 @@ class TestLocalFSSymlink(CommonLocalFSSymlinkTest):
         shutil.rmtree(self.tmpdir)
 
 
-class TestMemoryFSSymlink(CommonLocalFSSymlinkTest):
+class TestMemoryFSSymlink(CleanupMemoryBeforeTestMixin, CommonLocalFSSymlinkTest):
     __test__ = True
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestMemoryFSSymlink, self).setUp()
         self.baseurl = "memory:///"
 
     def tearDown(self):

--- a/tests/test_fs_symlink_copy.py
+++ b/tests/test_fs_symlink_copy.py
@@ -509,11 +509,11 @@ class TestLocalFSSymlinkCopy(CommonLocalFSSymlinkCopyTest):
         shutil.rmtree(self.tmpdir)
 
 
-class TestMemoryFSSymlinkCopy(CommonLocalFSSymlinkCopyTest):
+class TestMemoryFSSymlinkCopy(CleanupMemoryBeforeTestMixin, CommonLocalFSSymlinkCopyTest):
     __test__ = True
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestMemoryFSSymlinkCopy, self).setUp()
         self.baseurl = "memory:///"
 
     def tearDown(self):

--- a/tests/test_fs_symlink_copy.py
+++ b/tests/test_fs_symlink_copy.py
@@ -3,20 +3,19 @@
 #******************************************************************************
 
 from __future__ import with_statement
-import datetime
 import os
-import time
 import tempfile
-import stat
-import sys
-from posixpath import join as ujoin
-from unittest import TestCase
-import logging
 import shutil
-from common import create_file, os_create_file, load_file, mac_only, is_on_mac
+from unittest import TestCase
+
 from abl.vpath.base import *
-from abl.vpath.base.fs import CONNECTION_REGISTRY
-from abl.vpath.base.exceptions import FileDoesNotExistError
+
+from .common import (
+    create_file,
+    load_file,
+    is_on_mac,
+    CleanupMemoryBeforeTestMixin,
+)
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test_fs_symlink_loops.py
+++ b/tests/test_fs_symlink_loops.py
@@ -226,11 +226,11 @@ class TestLocalFSSymlinkLoop(CommonLocalFSSymlinkLoopTest):
         shutil.rmtree(self.tmpdir)
 
 
-class TestMemoryFSSymlinkLoop(CommonLocalFSSymlinkLoopTest):
+class TestMemoryFSSymlinkLoop(CleanupMemoryBeforeTestMixin, CommonLocalFSSymlinkLoopTest):
     __test__ = True
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestMemoryFSSymlinkLoop, self).setUp()
         self.baseurl = "memory:///"
 
     def tearDown(self):

--- a/tests/test_fs_symlink_loops.py
+++ b/tests/test_fs_symlink_loops.py
@@ -3,20 +3,20 @@
 #******************************************************************************
 
 from __future__ import with_statement
-import datetime
 import os
-import time
 import tempfile
 import stat
-import sys
-from posixpath import join as ujoin
 from unittest import TestCase
-import logging
 import shutil
-from common import create_file, os_create_file, load_file, mac_only, is_on_mac
+
 from abl.vpath.base import *
-from abl.vpath.base.fs import CONNECTION_REGISTRY
-from abl.vpath.base.exceptions import FileDoesNotExistError
+
+from .common import (
+    create_file,
+    load_file,
+    is_on_mac,
+    CleanupMemoryBeforeTestMixin,
+)
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test_fs_symlink_remove.py
+++ b/tests/test_fs_symlink_remove.py
@@ -3,20 +3,20 @@
 #******************************************************************************
 
 from __future__ import with_statement
-import datetime
 import os
-import time
 import tempfile
-import stat
-import sys
-from posixpath import join as ujoin
 from unittest import TestCase
-import logging
 import shutil
-from common import create_file, os_create_file, load_file, mac_only, is_on_mac
 from abl.vpath.base import *
-from abl.vpath.base.fs import CONNECTION_REGISTRY
-from abl.vpath.base.exceptions import FileDoesNotExistError
+
+from .common import (
+    create_file,
+    os_create_file,
+    load_file,
+    mac_only,
+    is_on_mac,
+    CleanupMemoryBeforeTestMixin,
+)
 
 
 #-------------------------------------------------------------------------------

--- a/tests/test_fs_symlink_remove.py
+++ b/tests/test_fs_symlink_remove.py
@@ -102,11 +102,11 @@ class TestLocalFSSymlinkRemove(CommonLocalFSSymlinkRemoveTest):
         shutil.rmtree(self.tmpdir)
 
 
-class TestMemoryFSSymlinkRemove(CommonLocalFSSymlinkRemoveTest):
+class TestMemoryFSSymlinkRemove(CleanupMemoryBeforeTestMixin, CommonLocalFSSymlinkRemoveTest):
     __test__ = True
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestMemoryFSSymlinkRemove, self).setUp()
         self.baseurl = "memory:///"
 
     def tearDown(self):

--- a/tests/test_fs_walk.py
+++ b/tests/test_fs_walk.py
@@ -3,20 +3,19 @@
 #******************************************************************************
 
 from __future__ import with_statement
-import datetime
 import os
-import time
 import tempfile
-import stat
-import sys
-from posixpath import join as ujoin
 from unittest import TestCase
-import logging
 import shutil
-from common import create_file, os_create_file, load_file, mac_only, is_on_mac
 from abl.vpath.base import *
-from abl.vpath.base.fs import CONNECTION_REGISTRY
-from abl.vpath.base.exceptions import FileDoesNotExistError
+
+from .common import (
+    create_file,
+    os_create_file,
+    is_on_mac,
+    mac_only,
+    CleanupMemoryBeforeTestMixin,
+)
 
 
 class CommonFileSystemWalkTest(TestCase):

--- a/tests/test_fs_walk.py
+++ b/tests/test_fs_walk.py
@@ -507,11 +507,11 @@ class TestLocalFSSymlinkWalk(CommonFileSystemWalkTest):
         shutil.rmtree(self.tmpdir)
 
 
-class TestMemoryFSSymlinkWalk(CommonFileSystemWalkTest):
+class TestMemoryFSSymlinkWalk(CleanupMemoryBeforeTestMixin, CommonFileSystemWalkTest):
     __test__ = True
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestMemoryFSSymlinkWalk, self).setUp()
         self.baseurl = "memory:///"
 
     def tearDown(self):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6,7 +6,6 @@ from __future__ import with_statement
 
 from cStringIO import StringIO
 import errno
-import os
 import tempfile
 import time
 import stat
@@ -15,13 +14,12 @@ from unittest import TestCase
 from abl.util import LockFileObtainException
 from abl.vpath.base import URI
 from abl.vpath.base.exceptions import FileDoesNotExistError
-from abl.vpath.base.fs import CONNECTION_REGISTRY
-from common import create_file
+from .common import create_file, CleanupMemoryBeforeTestMixin
 
 
-class MemoryFSTests(TestCase):
+class MemoryFSTests(CleanupMemoryBeforeTestMixin, TestCase):
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(MemoryFSTests, self).setUp()
         self.temp_path = URI(tempfile.mktemp())
         self.temp_path.mkdir()
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -148,10 +148,10 @@ class MemoryFSTests(CleanupMemoryBeforeTestMixin, TestCase):
 
 
 
-class TestRemovalOfFilesAndDirs(TestCase):
+class TestRemovalOfFilesAndDirs(CleanupMemoryBeforeTestMixin, TestCase):
 
     def setUp(self):
-        CONNECTION_REGISTRY.cleanup(force=True)
+        super(TestRemovalOfFilesAndDirs, self).setUp()
         self.root_path = URI('memory:///')
 
     def test_first(self):
@@ -258,7 +258,7 @@ class TestRemovalOfFilesAndDirs(TestCase):
         error_dir = self.root_path / "error.dir"
         error_dir.mkdir()
 
-        def next_op_callback(path, func):
+        def next_op_callback(_path, _func):
             raise OSError(13, "Permission denied")
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,11 +5,15 @@
 #******************************************************************************
 from __future__ import with_statement
 import os
+from unittest import TestCase
 
 from abl.vpath.base.misc import TempFileHandle
+from abl.vpath.base import URI
+
+from .common import CleanupMemoryBeforeTestMixin
 
 
-class TestTempFileHandle:
+class TestTempFileHandle(object):
     def test_handle(self):
         fs = open('testfile', 'w')
         fs.write('hallo')
@@ -19,3 +23,54 @@ class TestTempFileHandle:
         assert content == 'hallo'
         assert not os.path.exists('testfile')
 
+
+class TestGlob(CleanupMemoryBeforeTestMixin, TestCase):
+
+    def test_globbing_by_prefix(self):
+        base = URI("memory:///")
+        a = base / "a.foo"
+        b = base / "b.bar"
+
+        for f in [a, b]:
+            with f.open("w") as outf:
+                outf.write("foo")
+
+        self.assertEqual([a], base.glob("*.foo"))
+
+
+    def test_globbing_by_prefix_in_subdir(self):
+        base = URI("memory:///") / "dir"
+        base.mkdir()
+        a = base / "a.foo"
+        b = base / "b.bar"
+
+        for f in [a, b]:
+            with f.open("w") as outf:
+                outf.write("foo")
+
+        self.assertEqual([a], base.glob("*.foo"))
+
+
+    def test_globbing_by_suffix(self):
+        base = URI("memory:///")
+        a = base / "a.foo"
+        b = base / "b.bar"
+
+        for f in [a, b]:
+            with f.open("w") as outf:
+                outf.write("foo")
+
+        self.assertEqual([a], base.glob("a.*"))
+
+
+    def test_globbing_by_suffix_in_subdir(self):
+        base = URI("memory:///") / "dir"
+        base.mkdir()
+        a = base / "a.foo"
+        b = base / "b.bar"
+
+        for f in [a, b]:
+            with f.open("w") as outf:
+                outf.write("foo")
+
+        self.assertEqual([a], base.glob("a.*"))


### PR DESCRIPTION
There was a bug in glob that would only allow for patterns like '*.foo' to match - but not the other way round, 'foo.*'

I added tests & fixed it, also some import-cleanups and code-unifications.