### PR TITLE
Improve unicode handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+/abl.vpath.egg-info

--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -11,6 +11,7 @@ import stat
 from Queue import Queue
 import re
 import shutil
+import sys
 import threading
 import time
 import traceback
@@ -26,6 +27,18 @@ from .exceptions import (NoSchemeError,
 
 
 #============================================================================
+
+def fstr_to_unicode(fstr):
+    if type(fstr) is str:
+        return fstr.decode(sys.getfilesystemencoding())
+    return fstr
+
+
+def unicode_to_fstr(unistr):
+    if type(unistr) is unicode:
+        return unistr.encode(sys.getfilesystemencoding())
+    return unistr
+
 
 class ConnectionRegistry(object):
     """
@@ -497,6 +510,11 @@ class BaseUri(object):
         @return: URI instance of joined path
         @rtype: URI
         """
+        if type(self.uri) is unicode:
+            args = [fstr_to_unicode(arg) for arg in args]
+        elif type(self.uri) is str:
+            args = [unicode_to_fstr(arg) for arg in args]
+
         sep = self.sep
         if sep != '/':
             args = [x.replace(sep, '/') for x in args]

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="abl.vpath",
-    version="0.8",
+    version="0.8.1",
     description="A OO-abstraction of file-systems",
     author="Stephan Diehl",
     author_email="stephan.diehl@ableton.com",

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,7 @@
+# -*- coding: utf-8 -*-
+
 #******************************************************************************
-# (C) 2008-2013 Ableton AG
+# (C) 2008-2017 Ableton AG
 #******************************************************************************
 from __future__ import with_statement
 import datetime
@@ -80,8 +82,8 @@ class TestUnicodeURI(TestCase):
 
 
     def test_creation(self):
-        local_path = URI(u'/tmp/this')
-        self.assertEqual(local_path.path.split(os.sep), ['', 'tmp', 'this'])
+        local_path = URI(u'/tmp/thisü')
+        self.assertEqual(local_path.path.split(os.sep), ['', 'tmp', u'thisü'])
         self.assertEqual(local_path.scheme, 'file')
 
 
@@ -91,7 +93,7 @@ class TestUnicodeURI(TestCase):
 
 
     def test_unicode_extra(self):
-        p = URI(self.foo_dir, some_query=u"what's up")
+        p = URI(self.foo_dir, some_query=u"what's üp")
 
 
     def test_copy(self):
@@ -99,6 +101,16 @@ class TestUnicodeURI(TestCase):
         p.mkdir()
         dest = URI(self.bar_dir)
         p.copy(dest, recursive=True)
+
+
+    def test_dont_mix_unicode_and_bytes(self):
+        p = URI(u"Vögel")
+        p2 = p / "no_ünicode"
+        self.assertTrue(type(p2.uri) is unicode)
+
+        p3 = URI("Vögel")
+        p4 = p3 / u"ünicode"
+        self.assertTrue(type(p4.uri) is str)
 
 
 class TestCredentials(TestCase):


### PR DESCRIPTION
I had a lot of UnicodeDecodeExceptions in a _downstream project_ caused by mixing unicode and non-unicode strings in a vpath URI. It wasn't feasible to correct all the incoming strings. However, converting them to/from the filesystem representation is probably always the right thing to do. Teach vpath to deal with it.