### PR TITLE
Improve symlink support

### DIFF
--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -780,15 +780,19 @@ class BaseUri(object):
 
 
     @with_connection
-    def info(self, set_info=None):
+    def info(self, set_info=None, followlinks=True):
         """
         info: backend info about self (probably not implemented for
-              all backends. The result will be backend specific
+              all backends. The result will be backend specific).
 
+        @param set_info: If not None, this data will be set on self.
+        @param followlinks: If True, symlinks will be followed. If
+            False, the info of the symlink itself will be returned.
+            (Default: True)
         @rtype: Bunch
         @return: backend specific information about self.
         """
-        return self.connection.info(self, set_info=set_info)
+        return self.connection.info(self, set_info=set_info, followlinks=followlinks)
 
 
     @with_connection
@@ -1098,7 +1102,7 @@ class FileSystem(object):
         raise NotImplementedError
 
 
-    def info(self,  path, set_info=None):
+    def info(self,  path, set_info=None, followlinks=True):
         raise NotImplementedError
 
 

--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -565,7 +565,10 @@ class BaseUri(object):
         @type other: URI
         @param other: the path to copy the metadata to.
 
-        Will copy file permissions, mtime, atime, etc. to path.
+        Will copy file permissions, mtime, atime, etc. to path. Note:
+        this ALWAYS follows symlinks. Consider using info with
+        followslinks set to False to read and write the stat info of a
+        symlink.
         """
         return self.connection.copystat(self, other)
 

--- a/abl/vpath/base/localfs.py
+++ b/abl/vpath/base/localfs.py
@@ -41,15 +41,19 @@ class LocalFileSystem(FileSystem):
         pass
 
 
-    def info(self, unc, set_info=None):
+    def info(self, unc, set_info=None, followlinks=True):
         p = self._path(unc)
+
+        use_link_functions = self.islink(unc) and not followlinks
+        stat_func = os.lstat if use_link_functions else os.stat
+        chmod_func = os.lchmod if use_link_functions else os.chmod
 
         if set_info is not None:
             if "mode" in set_info:
-                os.chmod(p, set_info["mode"])
+                chmod_func(p, set_info["mode"])
             return
 
-        stats = os.stat(p)
+        stats = stat_func(p)
         ctime = stats[stat.ST_CTIME]
         mtime = stats[stat.ST_MTIME]
         atime = stats[stat.ST_ATIME]

--- a/abl/vpath/base/memory.py
+++ b/abl/vpath/base/memory.py
@@ -185,6 +185,11 @@ class MemorySymlink(object):
 
     def __init__(self, target):
         self.target = target
+        self.mtime = self.ctime = time.time()
+        self.mode = 0
+
+    def size(self):
+        return 8
 
 
 class MemoryFileSystemUri(BaseUri):
@@ -459,11 +464,13 @@ class MemoryFileSystem(FileSystem):
         traverse(self._fs)
         outf.write("MEMORY DUMP: END\n")
 
-    def info(self, unc, set_info=None):
-        current = self._get_node_for_path(self._fs, unc)
+    def info(self, unc, set_info=None, followlinks=True):
+        current = self._get_node_for_path(self._fs, unc, follow_link=followlinks)
         if set_info is not None:
             if "mode" in set_info:
                 current.mode = set_info["mode"]
+            if "mtime" in set_info:
+                current.mtime = set_info["mtime"]
             return
 
         return Bunch(mtime=current.mtime,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="abl.vpath",
-    version="0.8.1",
+    version="0.8.2",
     description="A OO-abstraction of file-systems",
     author="Stephan Diehl",
     author_email="stephan.diehl@ableton.com",

--- a/tests/test_localfs.py
+++ b/tests/test_localfs.py
@@ -24,12 +24,18 @@ class TestLocalFSInfo(TestCase):
         p = URI("test.txt")
         with p.open("w") as fs:
             fs.write('test')
+        a_link = URI("test_link")
+        if p.connection.supports_symlinks() and not a_link.islink():
+            p.symlink(a_link)
 
 
     def tearDown(self):
         p = URI("test.txt")
         if p.exists():
             p.remove()
+        l = URI("test_link")
+        if l.islink():
+            l.remove()
 
 
     def test_info_ctime(self):
@@ -48,6 +54,27 @@ class TestLocalFSInfo(TestCase):
         self.assert_( p.info().size > size)
         # due to now's millisecond resolution, we must ignore milliseconds
         self.assert_(p.info().mtime.timetuple()[:6] >= now.timetuple()[:6])
+
+
+    def test_info_on_symlinks(self):
+        a_file = URI("test.txt")
+        a_link = URI("test_link")
+        with a_file.open('w') as f:
+            f.write("a" * 800)
+
+        if not a_file.connection.supports_symlinks():
+            return
+
+        self.assertEqual(a_file.info().size, 800)
+        self.assertEqual(a_link.info().size, 800)
+        self.assertNotEqual(a_link.info(followlinks=False).size, 800)
+
+        orig_info = a_file.info()
+        a_link.info({'mode': 0120700}, followlinks=False)
+
+        self.assertEqual(a_file.info().mode, orig_info.mode)
+        self.assertEqual(a_link.info().mode, orig_info.mode)
+        self.assertEqual(a_link.info(followlinks=False).mode, 0120700)
 
 
     def test_locking(self):

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -68,6 +68,28 @@ class MemoryFSTests(CleanupMemoryBeforeTestMixin, TestCase):
         print out.getvalue()
 
 
+    def test_info_on_symlinks(self):
+        root = self.root
+        a_file = root / "a_file"
+        a_link = root / "a_link"
+        with a_file.open('w') as f:
+            f.write("a" * 800)
+        a_file.symlink(a_link)
+
+        self.assertEqual(a_file.info().size, 800)
+        self.assertEqual(a_link.info().size, 800)
+        self.assertNotEqual(a_link.info(followlinks=False).size, 800)
+
+        orig_info = a_file.info()
+        new_info = a_file.info()
+        new_info.mtime = new_info.mtime + 100
+        a_link.info(new_info, followlinks=False)
+
+        self.assertEqual(a_file.info().mtime, orig_info.mtime)
+        self.assertEqual(a_link.info().mtime, orig_info.mtime)
+        self.assertEqual(a_link.info(followlinks=False).mtime, new_info.mtime)
+
+
     def test_listdir_empty_root(self):
         root = self.root
         files = root.listdir()


### PR DESCRIPTION
Another needed improvement to vpath, this time it allows one to get the file info of a symlink instead of the info of the file it points to. I need this for a downstream project, again.

@dir-ableton could you take a look and merge if you are happy? This bumps vpath to 0.8.2.