### PR TITLE
Add Python 3.8 / 3.9 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Python 3.8, 3.9 support
+
+## 0.9 - 2018-09-18
+
+### Added
+
 - Python 3.5, 3.6, 3.7 support
 
 ### Changed
@@ -16,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Memory files are always stored as binary streams and are encoded/decoded
   based on the mode (r, rb, w, wb)
 - Switch to Python's standard zipfile libary
+
+### Removed
+
 - Python 2.5, 2.6 support
 
 ## 0.8 - 2015-09-03

--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -172,7 +172,7 @@ class ConnectionRegistry(object):
         """
         self.run_clean_thread = False
         self.cleanup(True)
-        if self.cleaner_thread.isAlive():
+        if self.cleaner_thread.is_alive():
             self.cleaner_thread.join()
 
 

--- a/abl/vpath/base/memory.py
+++ b/abl/vpath/base/memory.py
@@ -77,6 +77,14 @@ class MemoryFile(object):
         return self._data.flush()
 
 
+    def truncate(self, pos=None):
+        return self._data.truncate(pos)
+
+
+    def seekable(self):
+        return self._data.seekable()
+
+
     def __unicode__(self):
         return self._data.getvalue().decode('utf-8')
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="abl.vpath",
-    version="0.9",
+    version="0.10",
     description="A OO-abstraction of file-systems",
     author="Stephan Diehl",
     author_email="stephan.diehl@ableton.com",
@@ -13,7 +13,7 @@ setup(
         "abl.util",
         ],
     packages=find_packages(exclude=['ez_setup', 'tests']),
-    classifiers = [
+    classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
@@ -25,6 +25,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: System :: Filesystems',
     ],


### PR DESCRIPTION
* Replace deprecated Thread.isAlive with is_alive

is_alive is available since 2.6. isAlive has been deprecated in 3.8 and
removed in 3.9.

* Fix errors handling zip files on Python 3.8 and 3.9