### PR TITLE
Compatibility changes for Live's AppWebConnector

### DIFF
--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -335,10 +335,12 @@ class BaseUri(object):
     @property
     def path(self):
         path = self.parse_result.path
-        if path.startswith('/.'):
-            return path[1:]
-        else:
-            return path
+        parsed_path = path[1:] if path.startswith("/.") else path
+
+        if os.name == "nt" and self.scheme == "file":
+            parsed_path = os.path.normpath(re.sub(r"^/([a-zA-Z])/", r"\1:/", parsed_path))
+
+        return parsed_path
 
 
     @property

--- a/abl/vpath/base/localfs.py
+++ b/abl/vpath/base/localfs.py
@@ -151,7 +151,7 @@ class LocalFileSystem(FileSystem):
 
 
     def lock(self, path, fail_on_lock, cleanup):
-        return LockFile(str(path), fail_on_lock=fail_on_lock, cleanup=cleanup)
+        return LockFile(self._path(path), fail_on_lock=fail_on_lock, cleanup=cleanup)
 
 
     def mtime(self, path):

--- a/abl/vpath/base/memory.py
+++ b/abl/vpath/base/memory.py
@@ -69,6 +69,10 @@ class MemoryFile(object):
         self._data.seek(to, whence)
 
 
+    def seekable(self):
+        return self._data.seekable()
+
+
     def tell(self):
         return self._data.tell()
 

--- a/abl/vpath/base/memory.py
+++ b/abl/vpath/base/memory.py
@@ -143,8 +143,8 @@ class MemoryFileProxy(object):
 
 
     def encode(self, data):
-        return data if self.binary else data.encode('utf-8')
 
+        return data if self.binary or isinstance(data, bytes) else data.encode("utf-8")
 
     def decode(self, data):
         return data if self.binary else data.decode('utf-8')


### PR DESCRIPTION
This PR fixes a few small issues in `abl.vpath` that we ran in to while upgrading the code for the web connector in Live to python 3. It seems like the webconnector might be using `abl.vpath` in ways that the web team does not, and so these issues weren't found before.