### PR TITLE
Remove pkg_resources in favor of importlib.metadata

### DIFF
--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -2,6 +2,7 @@ import atexit
 from collections import defaultdict
 import fnmatch
 import hashlib
+from importlib.metadata import entry_points
 import os
 import stat
 import re
@@ -11,8 +12,6 @@ import time
 import traceback
 
 from decorator import decorator
-import pkg_resources
-
 from .simpleuri import UriParse, uri_from_parts
 from .exceptions import (NoSchemeError,
                          FileDoesNotExistError,
@@ -1116,7 +1115,7 @@ class RevisionedFileSystem(FileSystem):
         raise NotImplementedError
 
 
-for entrypoint in pkg_resources.iter_entry_points('abl.vpath.plugins'):
+for entrypoint in entry_points(group='abl.vpath.plugins'):
     try:
         plugin_class = entrypoint.load()
     except Exception as exp:

--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -1115,7 +1115,7 @@ class RevisionedFileSystem(FileSystem):
         raise NotImplementedError
 
 
-for entrypoint in entry_points(group='abl.vpath.plugins'):
+for entrypoint in entry_points().select(group='abl.vpath.plugins'):
     try:
         plugin_class = entrypoint.load()
     except Exception as exp:

--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -1115,7 +1115,7 @@ class RevisionedFileSystem(FileSystem):
         raise NotImplementedError
 
 
-for entrypoint in entry_points().select(group='abl.vpath.plugins'):
+for entrypoint in entry_points().get('abl.vpath.plugins') or []:
     try:
         plugin_class = entrypoint.load()
     except Exception as exp:


### PR DESCRIPTION
## Description

abl.vpath uses `pkg_resources` to load its plugins. It's been deprecated for a while and will be ditched in Python 3.12. It also seems to cause issues when used with the modern packaging facilities. Drop `pkg_resources` in favor of `importlib.metadata`.

## Related Tickets

Sentry: https://teamcity.office.ableton.com/buildConfiguration/AbletonCom_DebianPackageWorkflow_TestAbletonComOnUbuntu2004/220330