### PR TITLE
Fix selecting entry points for Python 3.12

### DIFF
--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -1115,7 +1115,16 @@ class RevisionedFileSystem(FileSystem):
         raise NotImplementedError
 
 
-for entrypoint in entry_points().get('abl.vpath.plugins') or []:
+entry_points = entry_points()
+try:
+    # Python versions prior to 3.10 return a simple dictonary of entry points
+    selected_entry_points = entry_points.get('abl.vpath.plugins', [])
+except AttributeError:
+    # Python 3.10 returns a dedicated selection interface
+    # Python 3.12 removed the old dictionary interface
+    selected_entry_points = entry_points.select(group='abl.vpath.plugins')
+
+for entrypoint in selected_entry_points:
     try:
         plugin_class = entrypoint.load()
     except Exception as exp:


### PR DESCRIPTION
Turns out the interface for selecting entry points by group in `importlib.metadata` changed between Python 3.8 and 3.12. The old interface was completely removed in Python 3.12 whereas the new interface was only introduce in Python 3.10. This fix tries both variants. There are third-party libraries that backport the new interface to old Python versions but since we will be moving to 3.12 soon anyway I didn't want to introduce yet another dependency.