### PR TITLE
Fix homegrown `lchmod` replacement

### DIFF
--- a/abl/vpath/base/localfs.py
+++ b/abl/vpath/base/localfs.py
@@ -23,7 +23,7 @@ LOGGER = logging.getLogger(__name__)
 
 def lchmod(filename, mode):
     if sys.version_info[0] >= 3:
-        return os.chmod(filename, mode, follow_symlinks=True)
+        return os.chmod(filename, mode, follow_symlinks=False)
     else:
         return os.lchmod(filename, mode)
 


### PR DESCRIPTION
Mirroring the fix in https://github.com/AbletonAppDev/live/pull/36972:

From `lchmod` documentation on https://docs.python.org/3/library/os.html

```
Change the mode of path to the numeric mode. If path is a symlink,
this affects the symlink rather than the target. See the docs for
chmod() for possible values of mode. As of Python 3.3, this
is equivalent to os.chmod(path, mode, follow_symlinks=False).
```