### PR TITLE
Strip leading "./" when getting path from URI

### DIFF
--- a/abl/vpath/base/fs.py
+++ b/abl/vpath/base/fs.py
@@ -333,13 +333,22 @@ class BaseUri(object):
 
     @property
     def path(self):
-        path = self.parse_result.path
-        parsed_path = path[1:] if path.startswith("/.") else path
+        def clean_path(p):
+            match p:
+                case x if x.startswith("/."):
+                    return x[1:]
+                case x if x.startswith("./"):
+                    return x[2:]
+                case _:
+                    return p
 
+        path = clean_path(self.parse_result.path)
+
+        # Restore : after drive letter on Windows
         if os.name == "nt" and self.scheme == "file":
-            parsed_path = os.path.normpath(re.sub(r"^/([a-zA-Z])/", r"\1:/", parsed_path))
+            return os.path.normpath(re.sub(r"^/([a-zA-Z])/", r"\1:/", path))
 
-        return parsed_path
+        return path
 
 
     @property

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -147,10 +147,10 @@ class TestURI(TestCase):
         self.assertEqual(local_path.scheme, 'file')
 
         path = URI('localpath', sep='/')
-        self.assertEqual(path.path, './localpath', path.path)
+        self.assertEqual(path.path, 'localpath', path.path)
 
         path = URI('trailing/slash/', sep='/')
-        self.assertEqual(path.path, './trailing/slash/')
+        self.assertEqual(path.path, 'trailing/slash/')
 
 
     def test_split(self):


### PR DESCRIPTION
URI adds a leading "./" for relative paths in the URI string, but if we leave this in place when getting the path back out of the URI, we may run into problems with code signing or auto update integrity. 